### PR TITLE
0.4.5 - Added option for older post footer styling

### DIFF
--- a/tumblr-custom-dash-palette.user.css
+++ b/tumblr-custom-dash-palette.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Tumblr – Custom Dashboard Palette
 @namespace      github.com/paw/tumblr-custom-palette-userstyle
-@version        0.4.4
+@version        0.4.5
 @description    `Set custom colors for your Tumblr dashboard.`
 @author         github.com/paw
 @updateURL      https://github.com/paw/tumblr-custom-palette-userstyle/raw/main/tumblr-custom-dash-palette.user.css
@@ -286,6 +286,37 @@ jumpbtn2 "Hide" <<<EOT
     main > div > button[aria-label="Restore timeline to what it was when you last viewed it"] {
         display: none !important;
     }
+EOT;
+}
+
+@advanced dropdown oldfooter 'Old post footer styling'{
+oldfooter1 "Disable" <<<EOT  EOT;
+oldfooter2 "Enable" <<<EOT
+body#tumblr footer.tOKgq.G6mnk {
+    display: flex;
+    padding: 0 var(--post-padding) var(--post-padding);
+    justify-content: space-between;
+    align-items: center;
+}
+body#tumblr footer.tOKgq.G6mnk > * {
+    padding: 5px 0;
+}
+body#tumblr footer.tOKgq.G6mnk .gstmW {
+    display: inline-flex;
+}
+body#tumblr .G6mnk .MCavR {
+    justify-content: flex-end;
+    margin: 0 0 0 auto;
+    border-top: none;
+    display: inline-flex;
+    padding: 5px 0;
+}
+body#tumblr .G6mnk .MCavR .sfGru, .MCavR .xkit-quick-tags-button {
+    margin: 0 12px;
+}
+body#tumblr .G6mnk .MCavR .sfGru:last-child {
+    margin-right: 0;
+}
 EOT;
 }
 
@@ -609,6 +640,8 @@ compactblockedpost2 "Enable" <<<EOT
     /*[[compactblockedpost]]*/
     
     /*[[jumpbtn]]*/
+    
+    /*[[oldfooter]]*/
     
     /*modal bg color*/
     body#tumblr button.SaLOl span.ZUy1d, body#tumblr .SaLOl[tabindex="-1"] {

--- a/tumblr-custom-dash-palette.user.css
+++ b/tumblr-custom-dash-palette.user.css
@@ -229,6 +229,7 @@ bgasidefix1 "Enable" <<<EOT
         background: RGB(var(--navy));
         border-radius: 6px;
         overflow: hidden;
+        display: none !important;
     }
     /*docked post fix overlay bg*\/
     body#tumblr .GDWdm {
@@ -290,20 +291,23 @@ EOT;
 }
 
 @advanced dropdown oldfooter 'Old post footer styling'{
-oldfooter1 "Disable" <<<EOT  EOT;
-oldfooter2 "Enable" <<<EOT
+oldfooter1 "Enabled" <<<EOT 
+/*footer*\/
 body#tumblr footer.tOKgq.G6mnk {
     display: flex;
     padding: 0 var(--post-padding) var(--post-padding);
     justify-content: space-between;
     align-items: center;
 }
+/*footer - all children have equal padding*\/
 body#tumblr footer.tOKgq.G6mnk > * {
     padding: 5px 0;
 }
+/*footer - notes container*\/
 body#tumblr footer.tOKgq.G6mnk .gstmW {
     display: inline-flex;
 }
+/*footer - post controls*\/
 body#tumblr .G6mnk .MCavR {
     justify-content: flex-end;
     margin: 0 0 0 auto;
@@ -311,13 +315,16 @@ body#tumblr .G6mnk .MCavR {
     display: inline-flex;
     padding: 5px 0;
 }
+/*footer - even post controls buttons margins + fix xkit quick tags margin*\/
 body#tumblr .G6mnk .MCavR .sfGru, .MCavR .xkit-quick-tags-button {
     margin: 0 12px;
 }
+/*footer - remove unnecessary right padding on last post control button*\/
 body#tumblr .G6mnk .MCavR .sfGru:last-child {
     margin-right: 0;
 }
 EOT;
+oldfooter2 "Disabled" <<<EOT  EOT;
 }
 
 @advanced dropdown followlabel "Follow Label" {


### PR DESCRIPTION
tumblr pushed a new update today to change the way the footer looks to emulate twitter's styling.
this update changes a few things back so it looks more like the old footer, with the option of disabling it.
this can be found under "Old post footer styling" and is enabled by default.

tumblr default:
![oldfooter1](https://user-images.githubusercontent.com/51191974/150411739-0d1c8c01-909f-4328-8081-ee076e66d7c9.png)
![oldfooter2](https://user-images.githubusercontent.com/51191974/150411741-4e651f9a-641c-47a9-9dd8-faeb4980a4ef.png)

newly added option for old footer styling:
![oldfooter3](https://user-images.githubusercontent.com/51191974/150411675-5bbd24f2-3738-4d24-b6d1-7f72de5164b4.png)
![oldfooter4](https://user-images.githubusercontent.com/51191974/150411677-28fb688e-9ff0-40b3-8cec-3e176bb60d40.png)
