### PR TITLE
0.4.6 - bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Click for larger preview.](https://raw.githubusercontent.com/paw/tumblr-custom-p
   * **Follower Notifications** = the custom background color for notifications from people you follow.
   * **Modal Reccomendations** = when clicked to view full size, some images now rarely suggest similar posts directly inside the modal itself underneath the fullsize picture. this toggle gives you the option to hide or show these suggested posts.
   * **Inline Recommendations** = this will hide the following inline recommendations:
+      * bonecoin ad / answertime link
       * inline blog suggestions ('check out these blogs')
       * inline tag suggestions on /tagged/ pages
       * the 'You're caught up. Check these out' carousel

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Click for larger preview.](https://raw.githubusercontent.com/paw/tumblr-custom-p
   * **Follower Notifications** = the custom background color for notifications from people you follow.
   * **Modal Reccomendations** = when clicked to view full size, some images now rarely suggest similar posts directly inside the modal itself underneath the fullsize picture. this toggle gives you the option to hide or show these suggested posts.
   * **Inline Recommendations** = this will hide the following inline recommendations:
-      * 'check out this post'/'look at this post you made' at the top of the dash
       * inline blog suggestions ('check out these blogs')
       * inline tag suggestions on /tagged/ pages
       * the 'You're caught up. Check these out' carousel

--- a/tumblr-custom-dash-palette.user.css
+++ b/tumblr-custom-dash-palette.user.css
@@ -400,6 +400,10 @@ modalsuggest2 "Hide" <<<EOT
     body#tumblr #glass-container .yPZfR:not(.xGwgY) {
         height: auto;
         margin-top: auto;
+    }
+    /*hide padding under modal reccomendations*\/
+    body#tumblr #glass-container .GHloH:not(.N8SnF) > .j8GND {
+        display: none;
     } EOT;
 }
 

--- a/tumblr-custom-dash-palette.user.css
+++ b/tumblr-custom-dash-palette.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Tumblr – Custom Dashboard Palette
 @namespace      github.com/paw/tumblr-custom-palette-userstyle
-@version        0.4.5
+@version        0.4.6
 @description    `Set custom colors for your Tumblr dashboard.`
 @author         github.com/paw
 @updateURL      https://github.com/paw/tumblr-custom-palette-userstyle/raw/main/tumblr-custom-dash-palette.user.css
@@ -376,16 +376,13 @@ inlinesuggest2 "Hide" <<<EOT
         2. headers for the recommendations + 'youre caught up, check these out' header
         3. 'youre caught up, check these out' content
         4. tag recommedations on /tagged/ pages
-        5. 'look at this post you made!' / 'check out this post'
     *\/
     body#tumblr .So6RQ > .ge_yK > .H14Pr.kDCXR,
     body#tumblr .So6RQ > .ge_yK > .HphhS,
     body#tumblr .So6RQ > .ge_yK > .Oii0L.kDCXR,
     body#tumblr .So6RQ > .ge_yK > .sKf2H > .luqhx > ._3fYLM,
     body#tumblr .j8ha0 > div[style] + div > .So6RQ:not([data-id]):first-child, /*#5 header *\/
-    body#tumblr .j8ha0 > div[style] + div > .So6RQ:not([data-id]):first-child + .So6RQ[data-id], /*#5 suggested post*\/
-    body#tumblr .j8ha0 > div[style] + div > .So6RQ:not([data-id]):first-child + .So6RQ:not([data-id]),
-    body#tumblr .j8ha0 > div[style] + div > .So6RQ:not([data-id]):first-child + .So6RQ:not([data-id]) + .So6RQ[data-id] {
+    body#tumblr .j8ha0 > div[style] + div > .So6RQ:not([data-id]):first-child + .So6RQ[data-id] {
         display: none !important;
     } EOT;
 inlinesuggest1 "Show" <<<EOT  EOT;

--- a/tumblr-custom-dash-palette.user.css
+++ b/tumblr-custom-dash-palette.user.css
@@ -224,6 +224,12 @@ bgasidefix1 "Enable" <<<EOT
         box-sizing: border-box;
         text-align: center;
     }
+    /*answertime container link fix*\/
+    body#tumblr .j8ha0 > div > .So6RQ:not([data-id]):first-child .ge_yK {
+        background: RGB(var(--navy));
+        border-radius: 6px;
+        overflow: hidden;
+    }
     /*docked post fix overlay bg*\/
     body#tumblr .GDWdm {
         background: rgb(var(--navy)) var(--custom-bg);

--- a/tumblr-custom-dash-palette.user.css
+++ b/tumblr-custom-dash-palette.user.css
@@ -395,6 +395,11 @@ modalsuggest2 "Hide" <<<EOT
     }
     body#tumblr #glass-container .GHloH:not(.N8SnF) {
         margin-top: 0;
+    }
+    /*fix modal padding when recommendations are hidden*\/
+    body#tumblr #glass-container .yPZfR:not(.xGwgY) {
+        height: auto;
+        margin-top: auto;
     } EOT;
 }
 

--- a/tumblr-custom-dash-palette.user.css
+++ b/tumblr-custom-dash-palette.user.css
@@ -224,13 +224,6 @@ bgasidefix1 "Enable" <<<EOT
         box-sizing: border-box;
         text-align: center;
     }
-    /*answertime container link fix*\/
-    body#tumblr .j8ha0 > div > .So6RQ:not([data-id]):first-child .ge_yK {
-        background: RGB(var(--navy));
-        border-radius: 6px;
-        overflow: hidden;
-        display: none !important;
-    }
     /*docked post fix overlay bg*\/
     body#tumblr .GDWdm {
         background: rgb(var(--navy)) var(--custom-bg);
@@ -376,13 +369,13 @@ inlinesuggest2 "Hide" <<<EOT
         2. headers for the recommendations + 'youre caught up, check these out' header
         3. 'youre caught up, check these out' content
         4. tag recommedations on /tagged/ pages
+	5. bonecoin ad / answertime link
     *\/
     body#tumblr .So6RQ > .ge_yK > .H14Pr.kDCXR,
     body#tumblr .So6RQ > .ge_yK > .HphhS,
     body#tumblr .So6RQ > .ge_yK > .Oii0L.kDCXR,
     body#tumblr .So6RQ > .ge_yK > .sKf2H > .luqhx > ._3fYLM,
-    body#tumblr .j8ha0 > div[style] + div > .So6RQ:not([data-id]):first-child, /*#5 header *\/
-    body#tumblr .j8ha0 > div[style] + div > .So6RQ:not([data-id]):first-child + .So6RQ[data-id] {
+    body#tumblr .j8ha0 > div > .So6RQ:not([data-id]):first-child .ge_yK {
         display: none !important;
     } EOT;
 inlinesuggest1 "Show" <<<EOT  EOT;


### PR DESCRIPTION
- I haven't personally seen a "look at this post you made" / "check out this post" post recently when testing and I noticed that the code meant to deal with them has been erroneously hiding the 1st post of the dashboard when the "you're all caught up, check this out" carousel is at the top of the dash. Due to this I'm removing the offending code for now. If these posts make a frequent return in the future, I'll see what I can do.
- Hiding Inline recommendations will now hide the bonecoin ad that's plaguing the dash right now.
- This update also contains a few small fixes to the image margins when modal recommendations are hidden.