### PR TITLE
0.6.3 - misc bug fixes & styling

### DIFF
--- a/tumblr-custom-dash-palette.user.css
+++ b/tumblr-custom-dash-palette.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Tumblr – Custom Dashboard Palette
 @namespace      github.com/paw/tumblr-custom-palette-userstyle
-@version        0.6.2
+@version        0.6.3
 @description    `Set custom colors for your Tumblr dashboard.`
 @author         github.com/paw
 @updateURL      https://github.com/paw/tumblr-custom-palette-userstyle/raw/main/tumblr-custom-dash-palette.user.css
@@ -78,7 +78,8 @@ bgasidefix1 "Enable" <<<EOT
         border-radius: 3px;
     }
     /*dashboard tabs aesthetic fix*\/
-    body#tumblr main.O4V_R > .p4DiZ.FMB1x {
+    body#tumblr main.O4V_R > .ZaYRY,
+    body#tumblr main.O4V_R > .ZaYRY .p4DiZ {
         border-radius: 3px;
     }
     /*following recommendation list el*\/
@@ -522,12 +523,12 @@ EOT;
 dashtabs1 "Show" <<<EOT  EOT;
 dashtabs2 "Hide" <<<EOT 
     /* hide dashboard tabs *\/
-    body#tumblr main.O4V_R > .p4DiZ.FMB1x {
+    body#tumblr main.O4V_R > .ZaYRY {
         display: none !important;
     }
     /* make sure icon doesn't move *\/
-    body#tumblr .FtjPK .AD_w7 .v_eRN {
-        top: 69px;
+    body#tumblr .FtjPK .AD_w7 .JZ10N {
+        top: 69px !important;
     } EOT;
 }
 
@@ -879,8 +880,8 @@ EOT;
 
 
 @-moz-document regexp("(http|https)://www\\.tumblr\\.com.*") {
-    :root {
-        --white: /*[[white-rgb]]*/; /*post bg*/
+    :root, body#tumblr {
+        --white: /*[[white-rgb]]*/ !important; /*post bg*/
         --white-on-dark: /*[[whiteondark-rgb]]*/;
         --black: /*[[black-rgb]]*/; /*font color*/
         
@@ -977,18 +978,22 @@ EOT;
     }
     
     /*dashboard tabs smaller font
-      1. tabs container span
-      2. tabs popover
+      1. tabs popover
+      2. tabs
     */
-    body#tumblr main.O4V_R > .p4DiZ.FMB1x > div,
-    body#tumblr #glass-container .ybmTG.ufrME> .DxQ0f.AzqQv > .rTGl_ {
+    body#tumblr #glass-container .ybmTG.ufrME> .DxQ0f.AzqQv > .rTGl_,
+    body#tumblr .ZaYRY .uM3pd {
         font-size: var(--menu-font-size);
     }
     /*dashboard tabs fix chevron size*/
-    body#tumblr main.O4V_R .p4DiZ.FMB1x .WojaA .hXMYF {
+    body#tumblr main.O4V_R > .ZaYRY .WojaA .hXMYF {
         font-size: 16px;
     }
     /*[[dashtabs]]*/
+    /*fix issue with "my tags" popover border styling*/
+    hr + .tBdaa {
+        border-top: none;
+    }
     
     /*in posts: reblog symbol & options menu dots */
     body#tumblr .jOhmG svg {
@@ -999,6 +1004,11 @@ EOT;
     }
     body#tumblr article header .KFWnx {
         align-items: start;
+    }
+    /*dividers*/
+    hr {
+        border-bottom: 1px solid transparent;
+        border-top: 1px solid rgba(var(--black),0.2);
     }
     /*link colors
         1. general
@@ -1101,6 +1111,7 @@ EOT;
         color: rgb(var(--green)) !important;
     }
     body#tumblr .hAFp3 .AXXSZ > a[style^="color"] svg {
+        --icon-color-primary: RGB(var(--green)) !important;
         fill: rgb(var(--green)) !important;
     }
     
@@ -1670,19 +1681,35 @@ EOT;
     /*peepr buttons will align in center for larger font sizes instead of stretching
       1. message button - modal popover
       2. message button - separate page
-      3. more options button - modal popover
-      4. more options button - separate page
-      5. gift ad free - modal popover
-      6. gift add free - separate page
+      3. gift ad free - modal popover
+      4. gift ad free - separate page
+      5. more options button - modal popover
+      6. more options button - separate page
+      7. mini blog options button set shown when viewing specific post - modal popover
+      8. mini blog options button set shown when viewing specific post - separate page
     */
-    body#tumblr #glass-container .F8bg3 > .uk9FI .oIdtb,
-    body#tumblr .RkANE .F8bg3 > .uk9FI .oIdtb,
-    body#tumblr #glass-container .BPf9u[data-testid="controlled-popover-wrapper"],
-    body#tumblr .RkANE .BPf9u[data-testid="controlled-popover-wrapper"],
-    body#tumblr #glass-container .F8bg3 > .uk9FI .TRX6J[aria-label="Gift Ad-Free"],
-    body#tumblr .RkANE .F8bg3 > .uk9FI .TRX6J[aria-label="Gift Ad-Free"]
+    body#tumblr #glass-container .uk9FI button[aria-label="Message"],
+    body#tumblr .RkANE .uk9FI button[aria-label="Message"],
+    body#tumblr #glass-container .F8bg3 > .uk9FI .TRX6J[aria-label="TumblrMart"],
+    body#tumblr .RkANE .F8bg3 > .uk9FI .TRX6J[aria-label="TumblrMart"],
+    body#tumblr #glass-container button[aria-label="Message"] + .BPf9u[data-testid="controlled-popover-wrapper"],
+    body#tumblr .RkANE button[aria-label="Message"] + .BPf9u[data-testid="controlled-popover-wrapper"],
+    body#tumblr #glass-container .F8bg3 > p.mFd_o + .uk9FI > *,
+    body#tumblr .RkANE .F8bg3 > p.mFd_o + .uk9FI > *
     {
         align-self: center;
+    }
+    /*peepr 'more like this' change header styling to work with custom bgs*/
+    body#tumblr #glass-container .FZkjV > h1.hF8Wr,
+    body#tumblr .RkANE .FZkjV > h1.hF8Wr {
+        padding: 10px;
+	    background: var(--color-bluespace-card-background);
+	    border-radius: var(--border-radius-small) var(--border-radius-small) 0 0;
+    }
+    body#tumblr #glass-container .FZkjV > h1.hF8Wr + .rD_LN,
+    body#tumblr .RkANE .FZkjV > h1.hF8Wr + .rD_LN {
+        margin-top: 0;
+        border-radius: 0 0 8px 8px;
     }
     /*bg color for image alt text textarea*/
     body#tumblr #glass-container .CXPww .JYYzJ {


### PR DESCRIPTION
### What's New
- More minor changes have been made to the dashboard's code, mainly relating to the dashboard tabs and some additions to the blog view popover Peepr.
- Frustratingly, Tumblr appears to have started obfuscating the names of their updated CSS files with random numbers instead of descriptive names:
![image](https://user-images.githubusercontent.com/51191974/192167781-73ecd084-d331-4758-b08f-6ebb59ab385e.png)

### Major Changes
- Nothing new has been added to the style.

### Bug Fixes & Minor Changes
- **Dashboard Tabs** - Code to hide them is now working again. Styling issues caused by the addition of an extra wrapper class is now fixed.
- **Minor Bugfixes**
  - Fixed issues with button styling for the new mini blog info box in the sidebar that's displayed when viewing an individual post via the dashboard blog viewer popover.
  - Styling adjustment for 'More Like This' header for suggested posts shown in the sidebar that's displayed when viewing an individual post via the dashboard blog viewer popover.
  - Pinned Post SVG will now be properly colored green.