### PR TITLE
0.8.1

### DIFF
--- a/tumblr-custom-dash-palette.user.css
+++ b/tumblr-custom-dash-palette.user.css
@@ -3440,10 +3440,21 @@ adfree2 "Show" <<<EOT  EOT;
     .POhPp[data-placement*="bottom-start"]::after {
         border-bottom-color: rgb(var(--tertiary-accent));
     }
+    /*new footer fix edit button color*/
+    body#tumblr article a.ndGZ1 {
+        color: var(--content-fg-secondary)
+    }
+    body#tumblr article a.ndGZ1.t8Z2i:hover {
+        color: var(--brand-blue)
+    }
+    /*legacy footer close notes button - prevent breaking in cases of very squished footer*/
+    body#tumblr .rlv6m .ePsyd {
+        white-space: nowrap;
+    }
     body#tumblr .MI6Q7 {
         --content-fg-tertiary: rgba(var(--black),0.5)
     }
-    /*footer fix alignment on notes with really big fonts*/
+    /*legacy footer fix alignment on notes with really big fonts*/
     footer[aria-label="Post Footer"] > .m5KTc > .gstmW .BPf9u[data-testid="controlled-popover-wrapper"] > .BPf9u {
         display: inline-flex;
     }
@@ -3612,6 +3623,18 @@ adfree2 "Show" <<<EOT  EOT;
     /*xkit timestamps*/
     .xkit-reblog-timestamp {
         text-align: right;
+    }
+    /*xkit quick tags button styling to match new edit and delete buttons*/
+    .xkit-quick-tags-button {
+        border-radius: 9999px;
+    }
+    .xkit-quick-tags-button:hover .xkit-control-button-inner svg {
+        fill: var(--brand-purple);
+    }
+    @media (hover: hover) and (pointer: fine) {
+        .xkit-quick-tags-button:hover {
+            background-color: var(--brand-purple-tint);
+        }
     }
     /*xkit sidebar fixes*/
     body#tumblr aside > .N5wJr + .zmjaW + .FZkjV + .FZkjV:not(:has(.Q55_h.KU8aS)) + #xkit-sidebar,

--- a/tumblr-custom-dash-palette.user.css
+++ b/tumblr-custom-dash-palette.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Tumblr – Custom Dashboard Palette
 @namespace      github.com/paw/tumblr-custom-palette-userstyle
-@version        0.8.0
+@version        0.8.1
 @description    `Set custom colors for your Tumblr dashboard.`
 @author         github.com/paw
 @updateURL      https://github.com/paw/tumblr-custom-palette-userstyle/raw/main/tumblr-custom-dash-palette.user.css
@@ -409,7 +409,7 @@ bgasidefix1 "Enable" <<<EOT
         6/7. no tags found on tagged page
         8. inbox description
     *\/
-    body#tumblr .R0TWs,
+    body#tumblr .R0TWs, body#tumblr .cQqe6,
     body#tumblr .j8ha0[data-timeline] .cQqe6,
     body#tumblr .j8ha0[data-timeline] .t3NIG,
     body#tumblr .s9s8Q.gifts,
@@ -656,11 +656,15 @@ otdpixiel2 "Enabled" <<<EOT
 EOT;
 }
 
-@advanced dropdown postfooter "Post Footer (Use DB+ to Get Exact Old Footer, a pure-CSS solution is incompatible with XKit's Quick Reblog atm)" {
+@advanced dropdown postfooter "Post Footer (Use DB+ to get the Old Footer back, a pure-CSS solution is not possible)" {
 postfooter0 "Default" <<<EOT  EOT;
 postfooter1 "Old Button Order & Aligned to Right" <<<EOT 
 body#tumblr footer.gm9gb .ndAE7 > div:not([class]) {
     order: -1;
+    display: flex;
+}
+body#tumblr footer.gm9gb .ndAE7 > div:not([class]) .xZAjr {
+    position: static;
 }
 body#tumblr footer.gm9gb .dbplus-controlIcon {
     order: -2;
@@ -680,31 +684,41 @@ body#tumblr footer.gm9gb .ndAE7 .rtfvT > span.Vcrhu {
 }
 EOT;
 postfooter2 "Old Button Order Only" <<<EOT 
-body#tumblr footer.gm9gb .ndAE7 > div:not([class]),
-body#tumblr footer.gm9gb .dbplus-controlIcon {
+body#tumblr footer.gm9gb .ndAE7 > div:not([class]) {
     order: -1;
     display: inline-flex;
-    justify-content: center;
-    width: 20%;
+    justify-content: space-around;
+    max-width: 50%;
+    width: auto;
+    flex: 1;
+}
+body#tumblr footer.gm9gb .ndAE7 > div:not([class]) .xZAjr {
+    position: static;
 }
 body#tumblr footer.gm9gb .dbplus-controlIcon {
+    display: inline-flex;
+    justify-content: center;
     order: -2;
-    width: 20%;
+    flex: 1;
 }
 body#tumblr footer.gm9gb .ndAE7 {
-    --cols: 4;
-    display: grid;
-    grid-template-columns: repeat(1fr, var(--cols))
-}
-body#tumblr footer.gm9gb:has(.dbplus-controlIcon) .ndAE7 {
-    --cols: 5;
+    display: flex;
+    gap: unset;
 }
 body#tumblr footer.gm9gb .ndAE7 .rtfvT {
-    grid-column: 2 / 4;
-    justify-items: center;
+    max-width: 80%;
+    justify-content: space-around;
+    display: flex;
+    width: auto;
+    min-width: 45%;
+    flex-grow: 1;
 }
-body#tumblr footer.gm9gb:has(.dbplus-controlIcon) .ndAE7 .rtfvT {
-    grid-column: 3 / 5;
+body#tumblr footer.gm9gb .ndAE7 .rtfvT > * {
+    flex: 1;
+}
+body#tumblr footer.gm9gb .ndAE7 .rtfvT .Vcrhu {
+    display: flex;
+    justify-content: center;
 }
 EOT;
 }
@@ -3610,4 +3624,3 @@ adfree2 "Show" <<<EOT  EOT;
         margin-top: 0.5em !important;
     }
 }
-


### PR DESCRIPTION
### What's New with Tumblr
- Tumblr brought back the Edit and Delete buttons.

### Major Changes
- N/A

### Bug Fixes & Minor Changes
- Fixed issue with Edit button being the color of links instead of the intended colors due to it being a link element instead of a button element.
- Fixed both alternative footer options to deal with the absolutely positioned blaze button on your own posts.
- Reworked old button order only footer option to utilize flex instead of the default grid, as it makes the positioning nicer (especially when add-ons have added additional buttons).
- Clarified that a pure-CSS option is not possible for re-creating the old post footer. This is due to separating the like/reblog count. XKit's quick reblog also interferes with re-positioning the reblogs label in a way that would mimic the old 'notes' button. I have chosen to recommend a different add-on to handle this as they utilize JavaScript and have already released options to revert the footer.
- Updated XKit Quick Reblog button styling to match the returned edit and delete buttons.
- "Layout Fixes for Custom Backgrounds" - Added background to the no posts message on empty blogs, as it looks like the class changed at some point. Kept the legacy class as well, just in case.